### PR TITLE
fix: Handle stale MechJeb references after save reload and vessel switching

### DIFF
--- a/kOS.MechJeb2.Addon/Addon.cs
+++ b/kOS.MechJeb2.Addon/Addon.cs
@@ -27,6 +27,14 @@ namespace kOS.MechJeb2.Addon
         public override BooleanValue Available()
         {
             Log.Debug("MJAddon.Available() called");
+
+            // Check if GameEvents triggered reinitialization (save reload, vessel change, scene change)
+            if (MechJebController.NeedsReinitialization)
+            {
+                Log.Debug("NeedsReinitialization flag set - forcing reinitialization");
+                MechJebController.Instance.ForceReinitialize();
+            }
+
             return MechJebController.Instance.IsAvailable;
         }
 

--- a/kOS.MechJeb2.Addon/Core/IBaseWrapper.cs
+++ b/kOS.MechJeb2.Addon/Core/IBaseWrapper.cs
@@ -6,6 +6,12 @@ namespace kOS.MechJeb2.Addon.Core
     {
         void Initialize();
 
+        /// <summary>
+        /// Reinitialize the wrapper, clearing any cached references.
+        /// Used after save reloads or vessel changes when MechJeb references become stale.
+        /// </summary>
+        void Reinitialize();
+
         bool Initialized { get; }
     }
 }

--- a/kOS.MechJeb2.Addon/MechJebController.cs
+++ b/kOS.MechJeb2.Addon/MechJebController.cs
@@ -41,7 +41,25 @@ namespace kOS.MechJeb2.Addon
 
         private static MechJebController _instance;
 
-        public static MechJebController Instance => _instance ??= new MechJebController();
+        public static MechJebController Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new MechJebController();
+                }
+
+                // Retry event subscription if it failed during construction
+                // (GameEvents may not have been ready during scene transitions)
+                if (!_eventsSubscribed)
+                {
+                    EnsureEventsSubscribed();
+                }
+
+                return _instance;
+            }
+        }
 
         public bool IsAvailable => _wrappers.All(w => w.Value.Initialized);
 

--- a/kOS.MechJeb2.Addon/MechJebController.cs
+++ b/kOS.MechJeb2.Addon/MechJebController.cs
@@ -6,9 +6,21 @@ using kOS.Safe.Encapsulation;
 
 namespace kOS.MechJeb2.Addon
 {
+    /// <summary>
+    /// Controller that manages MechJeb wrapper instances.
+    /// Subscribes to GameEvents to detect save reloads and vessel changes,
+    /// ensuring that stale MechJeb references are automatically refreshed.
+    /// </summary>
     public class MechJebController
     {
         private readonly Dictionary<WrapperTypes, IBaseWrapper> _wrappers;
+        private static bool _eventsSubscribed;
+
+        /// <summary>
+        /// Set to true when GameEvents fire, signaling that cached references may be stale.
+        /// Addon should check this and call ForceReinitialize() if true.
+        /// </summary>
+        public static bool NeedsReinitialization { get; private set; }
 
         private MechJebController()
         {
@@ -23,18 +35,83 @@ namespace kOS.MechJeb2.Addon
             {
                 baseWrapper.Value.Initialize();
             }
+
+            EnsureEventsSubscribed();
         }
-        
+
         private static MechJebController _instance;
 
         public static MechJebController Instance => _instance ??= new MechJebController();
 
         public bool IsAvailable => _wrappers.All(w => w.Value.Initialized);
-        
+
         public MechJebCoreWrapper Core => _wrappers[WrapperTypes.Core] as MechJebCoreWrapper;
         public MechJebAscentWrapper AscentWrapper => _wrappers[WrapperTypes.Ascent] as MechJebAscentWrapper;
         public VesselStateWrapper VesselState => _wrappers[WrapperTypes.Vessel] as VesselStateWrapper;
         public MechJebInfoItemsWrapper InfoItems => _wrappers[WrapperTypes.Info] as MechJebInfoItemsWrapper;
+
+        /// <summary>
+        /// Force all wrappers to reinitialize, clearing stale MechJeb references.
+        /// Call this after detecting that GameEvents have fired (save reload, vessel change).
+        /// </summary>
+        public void ForceReinitialize()
+        {
+            foreach (var wrapper in _wrappers.Values)
+            {
+                wrapper.Reinitialize();
+            }
+            NeedsReinitialization = false;
+        }
+
+        /// <summary>
+        /// Subscribe to KSP GameEvents to detect when saves are reloaded or vessels change.
+        /// This ensures we clear stale MechJeb references when the flight scene changes.
+        /// </summary>
+        private static void EnsureEventsSubscribed()
+        {
+            if (_eventsSubscribed) return;
+
+            // Guard against GameEvents not being initialized yet
+            if (GameEvents.onFlightReady == null ||
+                GameEvents.onVesselChange == null ||
+                GameEvents.onGameSceneLoadRequested == null)
+            {
+                return;
+            }
+
+            try
+            {
+                // onFlightReady fires when entering flight scene (including save reloads)
+                GameEvents.onFlightReady.Add(OnFlightReady);
+
+                // onVesselChange fires when switching between vessels
+                GameEvents.onVesselChange.Add(OnVesselChange);
+
+                // onGameSceneLoadRequested fires before loading any scene (cleanup opportunity)
+                GameEvents.onGameSceneLoadRequested.Add(OnGameSceneLoadRequested);
+
+                _eventsSubscribed = true;
+            }
+            catch
+            {
+                // GameEvents exist but aren't ready to accept subscribers yet - will retry next access
+            }
+        }
+
+        private static void OnFlightReady()
+        {
+            NeedsReinitialization = true;
+        }
+
+        private static void OnVesselChange(Vessel vessel)
+        {
+            NeedsReinitialization = true;
+        }
+
+        private static void OnGameSceneLoadRequested(GameScenes scene)
+        {
+            NeedsReinitialization = true;
+        }
     }
 
     internal enum WrapperTypes


### PR DESCRIPTION
## Summary

Not sure this is the best way to fix!  Maybe you had something else in mind here - this does not need to be merged if there is a better approach - just want to help where I can but I'm very new to KSP addon dev and MechJeb. 

This PR fixes an issue where the addon would throw exceptions after loading a saved game or switching vessels. The cached MechJeb reference becomes a destroyed Unity object (Unity's "fake null"), and accessing properties on it throws exceptions.

### Changes:
- **BaseWrapper.cs**: Smart `MasterMechJeb` property that detects destroyed Unity objects and automatically fetches a fresh reference from `FlightGlobals.ActiveVessel`
- **MechJebController.cs**: Subscribes to GameEvents (`onFlightReady`, `onVesselChange`, `onGameSceneLoadRequested`) to detect when reinitialization is needed
- **IBaseWrapper.cs**: Adds `Reinitialize()` method for clearing cached references
- **Addon.cs**: Checks `NeedsReinitialization` flag in `Available()` and triggers `ForceReinitialize()` when needed

### Technical Details:

Unity objects destroyed during scene transitions appear as "fake nulls" - they compare equal to `null` but calling methods on them throws `MissingReferenceException`. The fix:

1. Detects destroyed objects by calling `ToString()` (returns "null" for destroyed objects, throws for some edge cases)
2. Automatically fetches a fresh MechJeb reference from the current active vessel using reflection
3. GameEvents trigger a flag that causes all wrappers to reinitialize on next access

## Test plan

- [ ] Start a new flight, verify `ADDONS:MJ:AVAILABLE` returns true
- [ ] Load a saved game (Quick Load), verify addon still works
- [ ] Switch vessels using `[` `]` keys, verify addon still works
- [ ] Return to Space Center and re-enter flight, verify addon still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)